### PR TITLE
Simplify registration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,9 +49,5 @@ scalacOptions ++= Seq(
 
 Test / logBuffered := false
 
-// Only show warnings and errors on the screen for compilations.
-// This applies to both test:compile and compile and is Info by default
-Compile / logLevel := Level.Warn
-
 // Level.INFO is needed to see detailed output when running tests
 Test / logLevel := Level.Info

--- a/src/main/scala/org/apache/spark/sql/expressions/KllExpressions.scala
+++ b/src/main/scala/org/apache/spark/sql/expressions/KllExpressions.scala
@@ -256,15 +256,12 @@ case class KllGetPmfCdf(first: Expression,
       s"""
          |${sketchEval.code}
          |${splitPointsEval.code}
-         |if (${sketchEval.isNull} || ${splitPointsEval.isNull}) {
-         |  boolean ${ev.isNull} = true;
-         |} else {
+         |if (!${sketchEval.isNull} && !${splitPointsEval.isNull}) {
          |  org.apache.datasketches.quantilescommon.QuantileSearchCriteria searchCriteria = ${if (isInclusive) "org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE" else "org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE"};
          |  final org.apache.datasketches.kll.KllDoublesSketch $sketch = org.apache.spark.sql.types.KllDoublesSketchType.wrap(${sketchEval.value});
          |  final double[] splitPoints = ((org.apache.spark.sql.catalyst.util.GenericArrayData)${splitPointsEval.value}).toDoubleArray();
          |  final double[] result = ${if (isPmf) s"$sketch.getPMF(splitPoints, searchCriteria)" else s"$sketch.getCDF(splitPoints, searchCriteria)"};
          |  org.apache.spark.sql.catalyst.util.GenericArrayData ${ev.value} = new org.apache.spark.sql.catalyst.util.GenericArrayData(result);
-         |  boolean ${ev.isNull} = false;
          |}
        """.stripMargin
     ev.copy(code = CodeBlock(Seq(code), Seq.empty))

--- a/src/main/scala/org/apache/spark/sql/expressions/KllExpressions.scala
+++ b/src/main/scala/org/apache/spark/sql/expressions/KllExpressions.scala
@@ -19,14 +19,16 @@ package org.apache.spark.sql.expressions
 
 import org.apache.datasketches.memory.Memory
 import org.apache.datasketches.kll.KllDoublesSketch
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpectsInputTypes, UnaryExpression, BinaryExpression}
-import org.apache.spark.sql.types.{AbstractDataType, DataType, ArrayType, DoubleType, KllDoublesSketchType}
-import org.apache.spark.sql.catalyst.expressions.NullIntolerant
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeBlock, CodegenContext, ExprCode}
 import org.apache.datasketches.quantilescommon.QuantileSearchCriteria
+import org.apache.spark.sql.types.KllDoublesSketchType
+
+import org.apache.spark.sql.types.{AbstractDataType, ArrayType, BooleanType, DataType, DoubleType}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ExpectsInputTypes, ImplicitCastInputTypes}
+import org.apache.spark.sql.catalyst.expressions.{UnaryExpression, TernaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Literal, NullIntolerant, RuntimeReplaceable}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeBlock, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
-import org.apache.spark.sql.catalyst.expressions.ExpressionDescription
-import org.apache.spark.sql.catalyst.expressions.ImplicitCastInputTypes
+import org.apache.spark.sql.catalyst.trees.TernaryLike
 
 @ExpressionDescription(
   usage = """
@@ -128,13 +130,73 @@ case class KllGetMax(child: Expression)
   }
 }
 
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr, expr, isInclusive) - Returns an approximation to the PMF
+      of the given KllDoublesSketch using the specified search criteria (default: inclusive, isInclusive = true)
+      or exclusive using the given split points.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(kll_sketch_agg(col), array(1.5, 3.5)) FROM VALUES (1.0), (2.0), (3.0) tab(col);
+       [0.3333333333333333, 0.6666666666666666, 0.0]
+  """
+)
+case class KllGetPmf(first: Expression,
+                     second: Expression,
+                     third: Expression)
+    extends RuntimeReplaceable
+    with ImplicitCastInputTypes
+    with TernaryLike[Expression] {
+
+    def this(first: Expression, second: Expression) = {
+        this(first, second, Literal(true))
+    }
+
+    override lazy val replacement: Expression = KllGetPmfCdf(first, second, third, true)
+    override def inputTypes: Seq[AbstractDataType] = Seq(KllDoublesSketchType, ArrayType(DoubleType), BooleanType)
+    override protected def withNewChildrenInternal(newFirst: Expression, newSecond: Expression, newThird: Expression): Expression = {
+        copy(first = newFirst, second = newSecond, third = newThird)
+    }
+}
+
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr, expr, isInclusive) - Returns an approximation to the PMF
+      of the given KllDoublesSketch using the specified search criteria (default: inclusive, isInclusive = true)
+      or exclusive using the given split points.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(kll_sketch_agg(col), array(1.5, 3.5)) FROM VALUES (1.0), (2.0), (3.0) tab(col);
+       [0.3333333333333333, 0.6666666666666666, 0.0]
+  """
+)
+case class KllGetCdf(first: Expression,
+                     second: Expression,
+                     third: Expression)
+    extends RuntimeReplaceable
+    with ImplicitCastInputTypes
+    with TernaryLike[Expression] {
+
+    def this(first: Expression, second: Expression) = {
+        this(first, second, Literal(true))
+    }
+
+    override lazy val replacement: Expression = KllGetPmfCdf(first, second, third, false)
+    override def inputTypes: Seq[AbstractDataType] = Seq(KllDoublesSketchType, ArrayType(DoubleType), BooleanType)
+    override protected def withNewChildrenInternal(newFirst: Expression, newSecond: Expression, newThird: Expression): Expression = {
+        copy(first = newFirst, second = newSecond, third = newThird)
+    }
+}
+
 
 /**
   * Returns the PMF and CDF of the given quantile search criteria.
   *
-  * @param left A KllDoublesSketch sketch, in serialized form
-  * @param right An array of split points, as doubles
-  * @param isInclusive If true, use INCLUSIVE else EXCLUSIVE
+  * @param first A KllDoublesSketch sketch, in serialized form
+  * @param second An array of split points, as doubles
+  * @param third A boolean flag for inclusive mode. If true, use INCLUSIVE else EXCLUSIVE
   * @param isPmf Whether to return the PMF (true) or CDF (false)
   */
 @ExpressionDescription(
@@ -149,29 +211,32 @@ case class KllGetMax(child: Expression)
        [0.3333333333333333, 0.6666666666666666, 0.0]
   """
 )
-case class KllGetPmfCdf(left: Expression,
-                        right: Expression,
-                        isInclusive: Boolean = true,
+case class KllGetPmfCdf(first: Expression,
+                        second: Expression,
+                        third: Expression,
                         isPmf: Boolean = false)
- extends BinaryExpression
+ extends TernaryExpression
  with ExpectsInputTypes
  with NullIntolerant
  with ImplicitCastInputTypes {
 
-  override protected def withNewChildrenInternal(newLeft: Expression,
-                                              newRight: Expression) = {
-    copy(left = newLeft, right = newRight, isInclusive = isInclusive, isPmf = isPmf)
+  lazy val isInclusive = third.eval().asInstanceOf[Boolean]
+
+  override protected def withNewChildrenInternal(newFirst: Expression,
+                                                 newSecond: Expression,
+                                                 newThird: Expression) = {
+    copy(first = newFirst, second = newSecond, third = newThird, isPmf = isPmf)
   }
 
   override def prettyName: String = "kll_get_pmf_cdf"
 
-  override def inputTypes: Seq[AbstractDataType] = Seq(KllDoublesSketchType, ArrayType(DoubleType))
+  override def inputTypes: Seq[AbstractDataType] = Seq(KllDoublesSketchType, ArrayType(DoubleType), BooleanType)
 
   override def dataType: DataType = ArrayType(DoubleType, containsNull = false)
 
-  override def nullSafeEval(leftInput: Any, rightInput: Any): Any = {
-    val sketchBytes = leftInput.asInstanceOf[Array[Byte]]
-    val splitPoints = rightInput.asInstanceOf[GenericArrayData].toDoubleArray
+  override def nullSafeEval(firstInput: Any, secondInput: Any, thirdInput: Any): Any = {
+    val sketchBytes = firstInput.asInstanceOf[Array[Byte]]
+    val splitPoints = secondInput.asInstanceOf[GenericArrayData].toDoubleArray
     val sketch = KllDoublesSketch.wrap(Memory.wrap(sketchBytes))
 
     val result: Array[Double] =
@@ -183,30 +248,30 @@ case class KllGetPmfCdf(left: Expression,
     new GenericArrayData(result)
   }
 
-  override protected def nullSafeCodeGen(ctx: CodegenContext, ev: ExprCode, f: (String, String) => String): ExprCode = {
-    val sketchEval = left.genCode(ctx)
+  override protected def nullSafeCodeGen(ctx: CodegenContext, ev: ExprCode, f: (String, String, String) => String): ExprCode = {
+    val sketchEval = first.genCode(ctx)
     val sketch = ctx.freshName("sketch")
-    val splitPointsEval = right.genCode(ctx)
+    val splitPointsEval = second.genCode(ctx)
     val code =
       s"""
          |${sketchEval.code}
          |${splitPointsEval.code}
          |if (${sketchEval.isNull} || ${splitPointsEval.isNull}) {
-         |  ${ev.isNull} = true;
+         |  boolean ${ev.isNull} = true;
          |} else {
-         |  QuantileSearchCriteria searchCriteria = ${if (isInclusive) "QuantileSearchCriteria.INCLUSIVE" else "QuantileSearchCriteria.EXCLUSIVE"};
+         |  org.apache.datasketches.quantilescommon.QuantileSearchCriteria searchCriteria = ${if (isInclusive) "org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE" else "org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE"};
          |  final org.apache.datasketches.kll.KllDoublesSketch $sketch = org.apache.spark.sql.types.KllDoublesSketchType.wrap(${sketchEval.value});
          |  final double[] splitPoints = ((org.apache.spark.sql.catalyst.util.GenericArrayData)${splitPointsEval.value}).toDoubleArray();
          |  final double[] result = ${if (isPmf) s"$sketch.getPMF(splitPoints, searchCriteria)" else s"$sketch.getCDF(splitPoints, searchCriteria)"};
-         |  GenericArrayData ${ev.value} = new GenericArrayData(result);
-         |  ${ev.isNull} = false;
+         |  org.apache.spark.sql.catalyst.util.GenericArrayData ${ev.value} = new org.apache.spark.sql.catalyst.util.GenericArrayData(result);
+         |  boolean ${ev.isNull} = false;
          |}
        """.stripMargin
     ev.copy(code = CodeBlock(Seq(code), Seq.empty))
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    nullSafeCodeGen(ctx, ev, (arg1, arg2) => s"($arg1, $arg2)")
+    nullSafeCodeGen(ctx, ev, (arg1, arg2, arg3) => s"($arg1, $arg2, $arg3)")
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/functions_ds.scala
+++ b/src/main/scala/org/apache/spark/sql/functions_ds.scala
@@ -24,8 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.aggregate.{KllDoublesSketchAgg, KllDoublesMergeAgg}
 import org.apache.spark.sql.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DoubleType}
 
 // this class defines and maps all the variants of each function invocation, analagous
 // to the functions object in org.apache.spark.sql.functions
@@ -87,11 +86,11 @@ object functions_ds {
 
   // get PMF
   def kll_get_pmf(sketch: Column, splitPoints: Column, isInclusive: Boolean): Column = withExpr {
-    new KllGetPmfCdf(sketch.expr, splitPoints.expr, isInclusive, true)
+    new KllGetPmfCdf(sketch.expr, splitPoints.expr, Literal.create(isInclusive, BooleanType), true)
   }
 
   def kll_get_pmf(sketch: Column, splitPoints: Column): Column = withExpr {
-    new KllGetPmfCdf(sketch.expr, splitPoints.expr, true, true)
+    new KllGetPmfCdf(sketch.expr, splitPoints.expr, Literal(true), true)
   }
 
   def kll_get_pmf(columnName: String, splitPoints: Column, isInclusive: Boolean): Column = {
@@ -121,11 +120,11 @@ object functions_ds {
 
   // get CDF
   def kll_get_cdf(sketch: Column, splitPoints: Column, isInclusive: Boolean): Column = withExpr {
-    new KllGetPmfCdf(sketch.expr, splitPoints.expr, isInclusive, false)
+    new KllGetPmfCdf(sketch.expr, splitPoints.expr, Literal.create(isInclusive, BooleanType), false)
   }
 
   def kll_get_cdf(sketch: Column, splitPoints: Column): Column = withExpr {
-    new KllGetPmfCdf(sketch.expr, splitPoints.expr, true, false)
+    new KllGetPmfCdf(sketch.expr, splitPoints.expr, Literal(true), false)
   }
 
   def kll_get_cdf(columnName: String, splitPoints: Column, isInclusive: Boolean): Column = {

--- a/src/main/scala/org/apache/spark/sql/types/KllDoublesSketchType.scala
+++ b/src/main/scala/org/apache/spark/sql/types/KllDoublesSketchType.scala
@@ -51,11 +51,11 @@ case object KllDoublesSketchType extends KllDoublesSketchType {
   })
 
   // non-udf version
-  val wrap = ((bytes: Array[Byte]) => {
+  def wrap(bytes: Array[Byte]): KllDoublesSketch = {
     if (bytes == null) {
       null
     } else {
       deserialize(bytes)
     }
-  })
+  }
 }

--- a/src/test/scala/org/apache/spark/sql/KllTest.scala
+++ b/src/test/scala/org/apache/spark/sql/KllTest.scala
@@ -58,7 +58,7 @@ class KllTest extends SparkSessionManager {
     ))
 
     val df = spark.createDataFrame(dataList, schema)
-    df.show()
+    assert(df.count() == numClass)
   }
 
   test("Create DataFrame from parallelize()") {
@@ -80,7 +80,7 @@ class KllTest extends SparkSessionManager {
     val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
       .select($"id", KllDoublesSketchType.wrapBytes($"kll").as("sketch"))
 
-    df.show()
+    assert(df.count() == numClass)
   }
 
   test("KLL Doubles Sketch via scala") {


### PR DESCRIPTION
A few unrelated changes:
* Check k in KLL sketch creation
* Modify PMF/CDF calls to simplify SQL registration (thanks @will-lauer !)
* Fix some codegen errors. There's still one for pmf/cdf that I have't figured out but the fallback to non-generated code works so it's not super urgent.

I'll try to get better at more targeted changes per PR but it's a little harder (for me) to do that while we're still in early work-in-progress mode and exploring the spark API and trying to establish reasonable patterns.