### PR TITLE
Rename for consistency

### DIFF
--- a/src/main/scala/org/apache/spark/sql/kll/aggregate/KllAggregate.scala
+++ b/src/main/scala/org/apache/spark/sql/kll/aggregate/KllAggregate.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
   """,
 )
 // scalastyle:on line.size.limit
-case class KllDoublesSketchAgg(
+case class KllDoublesSketchAggBuild(
     dataExpr: Expression,
     kExpr: Expression,
     mutableAggBufferOffset: Int = 0,
@@ -84,14 +84,14 @@ case class KllDoublesSketchAgg(
   }
 
   // Copy constructors
-  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): KllDoublesSketchAgg =
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): KllDoublesSketchAggBuild =
     copy(mutableAggBufferOffset = newMutableAggBufferOffset)
 
-  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): KllDoublesSketchAgg =
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): KllDoublesSketchAggBuild =
     copy(inputAggBufferOffset = newInputAggBufferOffset)
 
   override protected def withNewChildrenInternal(newLeft: Expression,
-                                                 newRight: Expression): KllDoublesSketchAgg = {
+                                                 newRight: Expression): KllDoublesSketchAggBuild = {
     copy(dataExpr = newLeft, kExpr = newRight)
   }
 

--- a/src/main/scala/org/apache/spark/sql/kll/aggregate/KllMerge.scala
+++ b/src/main/scala/org/apache/spark/sql/kll/aggregate/KllMerge.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
   //group = "agg_funcs",
 )
 // scalastyle:on line.size.limit
-case class KllDoublesSketchMergeAgg(
+case class KllDoublesSketchAggMerge(
     sketchExpr: Expression,
     kExpr: Expression,
     mutableAggBufferOffset: Int = 0,
@@ -86,13 +86,13 @@ case class KllDoublesSketchMergeAgg(
   }
 
   // Copy constructors
-  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): KllDoublesSketchMergeAgg =
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): KllDoublesSketchAggMerge =
     copy(mutableAggBufferOffset = newMutableAggBufferOffset)
 
-  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): KllDoublesSketchMergeAgg =
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): KllDoublesSketchAggMerge =
     copy(inputAggBufferOffset = newInputAggBufferOffset)
 
-  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): KllDoublesSketchMergeAgg =
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): KllDoublesSketchAggMerge =
     copy(sketchExpr = newLeft, kExpr = newRight)
 
   // overrides for TypedImperativeAggregate

--- a/src/main/scala/org/apache/spark/sql/registrar/KllFunctionRegistry.scala
+++ b/src/main/scala/org/apache/spark/sql/registrar/KllFunctionRegistry.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.registrar
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{ExpressionInfo}
 
-import org.apache.spark.sql.aggregate.{KllDoublesSketchAgg, KllDoublesSketchMergeAgg}
+import org.apache.spark.sql.aggregate.{KllDoublesSketchAggBuild, KllDoublesSketchAggMerge}
 import org.apache.spark.sql.expressions.{KllDoublesSketchGetMin, KllDoublesSketchGetMax, KllDoublesSketchGetPmf, KllDoublesSketchGetCdf}
 
 object KllFunctionRegistry extends DatasketchesFunctionRegistry {
   override val expressions: Map[String, (ExpressionInfo, FunctionBuilder)] = Map(
-    expression[KllDoublesSketchAgg]("kll_sketch_double_agg_build"),
-    expression[KllDoublesSketchMergeAgg]("kll_sketch_double_agg_merge"),
+    expression[KllDoublesSketchAggBuild]("kll_sketch_double_agg_build"),
+    expression[KllDoublesSketchAggMerge]("kll_sketch_double_agg_merge"),
     expression[KllDoublesSketchGetMin]("kll_sketch_double_get_min"),
     expression[KllDoublesSketchGetMax]("kll_sketch_double_get_max"),
     expression[KllDoublesSketchGetPmf]("kll_sketch_double_get_pmf"),

--- a/src/main/scala/org/apache/spark/sql/registrar/ThetaFunctionRegistry.scala
+++ b/src/main/scala/org/apache/spark/sql/registrar/ThetaFunctionRegistry.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.registrar
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{ExpressionInfo}
 
-import org.apache.spark.sql.aggregate.{ThetaSketchBuild, ThetaUnion}
+import org.apache.spark.sql.aggregate.{ThetaSketchAggBuild, ThetaSketchAggUnion}
 import org.apache.spark.sql.expressions.ThetaSketchGetEstimate
 
 object ThetaFunctionRegistry extends DatasketchesFunctionRegistry {
   override val expressions: Map[String, (ExpressionInfo, FunctionBuilder)] = Map(
-    expression[ThetaSketchBuild]("theta_sketch_build"),
-    expression[ThetaUnion]("theta_union"),
+    expression[ThetaSketchAggBuild]("theta_sketch_agg_build"),
+    expression[ThetaSketchAggUnion]("theta_sketch_agg_union"),
     expression[ThetaSketchGetEstimate]("theta_sketch_get_estimate")
   )
 }

--- a/src/main/scala/org/apache/spark/sql/registrar/functions_datasketches_kll.scala
+++ b/src/main/scala/org/apache/spark/sql/registrar/functions_datasketches_kll.scala
@@ -21,14 +21,14 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{ArrayType, BooleanType, DoubleType}
 
-import org.apache.spark.sql.aggregate.{KllDoublesSketchMergeAgg, KllDoublesSketchAgg}
+import org.apache.spark.sql.aggregate.{KllDoublesSketchAggMerge, KllDoublesSketchAggBuild}
 import org.apache.spark.sql.expressions.{KllDoublesSketchGetMin, KllDoublesSketchGetMax, KllDoublesSketchGetPmfCdf}
 
 object functions_datasketches_kll extends DatasketchesScalaFunctionBase {
 
   // build sketch
   def kll_sketch_double_agg_build(expr: Column, k: Column): Column = withAggregateFunction {
-    new KllDoublesSketchAgg(expr.expr, k.expr)
+    new KllDoublesSketchAggBuild(expr.expr, k.expr)
   }
 
   def kll_sketch_double_agg_build(expr: Column, k: Int): Column = {
@@ -40,7 +40,7 @@ object functions_datasketches_kll extends DatasketchesScalaFunctionBase {
   }
 
   def kll_sketch_double_agg_build(expr: Column): Column = withAggregateFunction {
-    new KllDoublesSketchAgg(expr.expr)
+    new KllDoublesSketchAggBuild(expr.expr)
   }
 
   def kll_sketch_double_agg_build(columnName: String): Column = {
@@ -49,7 +49,7 @@ object functions_datasketches_kll extends DatasketchesScalaFunctionBase {
 
   // merge sketches
   def kll_sketch_double_agg_merge(expr: Column): Column = withAggregateFunction {
-    new KllDoublesSketchMergeAgg(expr.expr)
+    new KllDoublesSketchAggMerge(expr.expr)
   }
 
   def kll_sketch_double_agg_merge(columnName: String): Column = {
@@ -57,11 +57,11 @@ object functions_datasketches_kll extends DatasketchesScalaFunctionBase {
   }
 
   def kll_sketch_double_agg_merge(expr: Column, k: Column): Column = withAggregateFunction {
-    new KllDoublesSketchMergeAgg(expr.expr, k.expr)
+    new KllDoublesSketchAggMerge(expr.expr, k.expr)
   }
 
   def kll_sketch_double_agg_merge(expr: Column, k: Int): Column = withAggregateFunction {
-    new KllDoublesSketchMergeAgg(expr.expr, lit(k).expr)
+    new KllDoublesSketchAggMerge(expr.expr, lit(k).expr)
   }
 
   def kll_sketch_double_agg_merge(columnName: String, k: Int): Column = {

--- a/src/main/scala/org/apache/spark/sql/registrar/functions_datasketches_theta.scala
+++ b/src/main/scala/org/apache/spark/sql/registrar/functions_datasketches_theta.scala
@@ -19,40 +19,40 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.functions.lit
 
-import org.apache.spark.sql.aggregate.{ThetaSketchBuild, ThetaUnion}
+import org.apache.spark.sql.aggregate.{ThetaSketchAggBuild, ThetaSketchAggUnion}
 import org.apache.spark.sql.expressions.ThetaSketchGetEstimate
 
 object functions_datasketches_theta extends DatasketchesScalaFunctionBase {
-  def theta_sketch_build(column: Column, lgk: Int): Column = withAggregateFunction {
-    new ThetaSketchBuild(column.expr, lgk)
+  def theta_sketch_agg_build(column: Column, lgk: Int): Column = withAggregateFunction {
+    new ThetaSketchAggBuild(column.expr, lgk)
   }
 
-  def theta_sketch_build(columnName: String, lgk: Int): Column = {
-    theta_sketch_build(Column(columnName), lgk)
+  def theta_sketch_agg_build(columnName: String, lgk: Int): Column = {
+    theta_sketch_agg_build(Column(columnName), lgk)
   }
 
-  def theta_sketch_build(column: Column): Column = withAggregateFunction {
-    new ThetaSketchBuild(column.expr)
+  def theta_sketch_agg_build(column: Column): Column = withAggregateFunction {
+    new ThetaSketchAggBuild(column.expr)
   }
 
-  def theta_sketch_build(columnName: String): Column = {
-    theta_sketch_build(Column(columnName))
+  def theta_sketch_agg_build(columnName: String): Column = {
+    theta_sketch_agg_build(Column(columnName))
   }
 
-  def theta_union(column: Column, lgk: Int): Column = withAggregateFunction {
-    new ThetaUnion(column.expr, lit(lgk).expr)
+  def theta_sketch_agg_union(column: Column, lgk: Int): Column = withAggregateFunction {
+    new ThetaSketchAggUnion(column.expr, lit(lgk).expr)
   }
 
-  def theta_union(columnName: String, lgk: Int): Column = withAggregateFunction {
-    new ThetaUnion(Column(columnName).expr, lit(lgk).expr)
+  def theta_sketch_agg_union(columnName: String, lgk: Int): Column = withAggregateFunction {
+    new ThetaSketchAggUnion(Column(columnName).expr, lit(lgk).expr)
   }
 
-  def theta_union(column: Column): Column = withAggregateFunction {
-    new ThetaUnion(column.expr)
+  def theta_sketch_agg_union(column: Column): Column = withAggregateFunction {
+    new ThetaSketchAggUnion(column.expr)
   }
 
-  def theta_union(columnName: String): Column = withAggregateFunction {
-    new ThetaUnion(Column(columnName).expr)
+  def theta_sketch_agg_union(columnName: String): Column = withAggregateFunction {
+    new ThetaSketchAggUnion(Column(columnName).expr)
   }
 
   def theta_sketch_get_estimate(column: Column): Column = withExpr {


### PR DESCRIPTION
* rename all (in theory) public-facing functions to be in line with bigquery's SQL style
* rename the underlying scala classes using CamelCase but with similar pattern