### PR TITLE
Scala version compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [ 8, 11, 17 ]
+        scala: [ 2.12.20, 2.13.16 ]
         spark: [ 3.4.4, 3.5.4 ]
 
     env:
       JDK_VERSION: ${{ matrix.jdk }}
+      SCALA_VERSION: ${{ matrix.scala }}
       SPARK_VERSION: ${{ matrix.spark }}
 
     steps:
@@ -38,8 +40,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: build-${{ runner.os }}-jdk-${{ matrix.jdk }}-spark-${{ matrix.spark }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: build-${{ runner.os }}-jdk-${{matrix.jdk}}-spark-${{ matrix.spark }}-maven-
+          key: build-${{ runner.os }}-jdk-${{ matrix.jdk }}-scala-${{ matrix.scala }}-spark-${{ matrix.spark }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: build-${{ runner.os }}-jdk-${{matrix.jdk}}-scala-${{ matrix.scala }}-spark-${{ matrix.spark }}-maven-
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -53,9 +55,11 @@ jobs:
       - name: Setup SBT
         uses: sbt/setup-sbt@v1
 
-      - name: Echo Java Version
+      - name: Echo config versions
         run: >
           java -version
+          echo Scala version: $SCALA_VERSION
+          echo Spark version: $SPARK_VERSION
 
       - name: Build and test
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test
+    name: JDK ${{ matrix.jdk }} - Scala ${{ matrix.scala }} - Spark ${{ matrix.spark }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,14 +56,14 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Echo config versions
-        run: >
+        run: |
           java -version
           echo Scala version: $SCALA_VERSION
           echo Spark version: $SPARK_VERSION
 
       - name: Build and test
         run: >
-          sbt --batch clean test
+          sbt ++$SCALA_VEERSION --batch clean test
 
 # Architecture options: x86, x64, armv7, aarch64, ppc64le
 # setup-java@v4 has a "with cache" option

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import scala.xml.dtd.DEFAULT
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,15 +18,21 @@
 
 name := "datasketches-spark"
 version := "1.0-SNAPSHOT"
-scalaVersion := "2.12.20"
+
+DEFAULT_SCALA_VERSION := "2.12.20"
+DEFAULT_SPARK_VERSION := "3.5.4"
+DEFAULT_JDK_VERSION := "11"
 
 organization := "org.apache.datasketches"
 description := "The Apache DataSketches package for Spark"
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
+val scalaVersion = settingKey[String]("The version of Scala")
+scalaVersion := sys.env.getOrElse("SCALA_VERSION", DEFAULT_SCALA_VERSION)
+
 val sparkVersion = settingKey[String]("The version of Spark")
-sparkVersion := sys.env.getOrElse("SPARK_VERSION", "3.5.4")
+sparkVersion := sys.env.getOrElse("SPARK_VERSION", DEFAULT_SPARK_VERSION)
 
 // determine our java version
 val jvmVersionString = settingKey[String]("The JVM version")
@@ -45,7 +52,7 @@ val jvmVersionMap = Map(
 val jvmVersion = settingKey[String]("The JVM major version")
 jvmVersion := jvmVersionMap.collectFirst {
   case (prefix, (major, _)) if jvmVersionString.value.startsWith(prefix) => major
-}.getOrElse("11")
+}.getOrElse(DEFAULT_JDK_VERSION)
 
 // look up the associated datasketches-java version
 val dsJavaVersion = settingKey[String]("The DataSketches Java version")
@@ -59,8 +66,8 @@ Test / scalacOptions ++= Seq("-encoding", "UTF-8", "-release", jvmVersion.value)
 
 libraryDependencies ++= Seq(
   "org.apache.datasketches" % "datasketches-java" % dsJavaVersion.value % "compile",
-  "org.scala-lang" % "scala-library" % "2.12.6",
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
+  "org.scala-lang" % "scala-library" % scalaVersion.value, // scala3-library may need to use %%
+  ("org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.19" % "test",
   "org.scalatestplus" %% "junit-4-13" % "3.2.19.0" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,6 @@ description := "The Apache DataSketches package for Spark"
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-val scalaVersion = settingKey[String]("The version of Scala")
 scalaVersion := sys.env.getOrElse("SCALA_VERSION", DEFAULT_SCALA_VERSION)
 
 val sparkVersion = settingKey[String]("The version of Spark")

--- a/build.sbt
+++ b/build.sbt
@@ -19,9 +19,9 @@ import scala.xml.dtd.DEFAULT
 name := "datasketches-spark"
 version := "1.0-SNAPSHOT"
 
-DEFAULT_SCALA_VERSION := "2.12.20"
-DEFAULT_SPARK_VERSION := "3.5.4"
-DEFAULT_JDK_VERSION := "11"
+val DEFAULT_SCALA_VERSION = "2.12.20"
+val DEFAULT_SPARK_VERSION = "3.5.4"
+val DEFAULT_JDK_VERSION = "11"
 
 organization := "org.apache.datasketches"
 description := "The Apache DataSketches package for Spark"

--- a/src/main/scala/org/apache/spark/sql/kll/expressions/KllDoublesSketchExpressions.scala
+++ b/src/main/scala/org/apache/spark/sql/kll/expressions/KllDoublesSketchExpressions.scala
@@ -260,7 +260,7 @@ case class KllDoublesSketchGetPmfCdf(sketchExpr: Expression,
     if (!isInclusiveExpr.foldable) {
       return TypeCheckResult.TypeCheckFailure(s"isInclusiveExpr must be foldable, but got: ${isInclusiveExpr}")
     }
-    if (splitPointsExpr.eval().asInstanceOf[GenericArrayData].numElements == 0) {
+    if (splitPointsExpr.eval().asInstanceOf[GenericArrayData].numElements() == 0) {
       return TypeCheckResult.TypeCheckFailure(s"splitPointsExpr must not be empty")
     }
 
@@ -269,7 +269,7 @@ case class KllDoublesSketchGetPmfCdf(sketchExpr: Expression,
 
   override def nullSafeEval(sketchInput: Any, splitPointsInput: Any, isInclusiveInput: Any): Any = {
     val sketchBytes = sketchInput.asInstanceOf[Array[Byte]]
-    val splitPoints = splitPointsInput.asInstanceOf[GenericArrayData].toDoubleArray
+    val splitPoints = splitPointsInput.asInstanceOf[GenericArrayData].toDoubleArray()
     val sketch = KllDoublesSketch.wrap(Memory.wrap(sketchBytes))
 
     val result: Array[Double] =

--- a/src/test/scala/org/apache/spark/sql/ThetaTest.scala
+++ b/src/test/scala/org/apache/spark/sql/ThetaTest.scala
@@ -28,7 +28,7 @@ class ThetaTest extends SparkSessionManager {
     val data = (for (i <- 1 to n) yield i).toDF("value")
 
     val sketchDf = data.agg(theta_sketch_agg_build("value").as("sketch"))
-    val result: Row = sketchDf.select(theta_sketch_get_estimate("sketch").as("estimate")).head
+    val result: Row = sketchDf.select(theta_sketch_get_estimate("sketch").as("estimate")).head()
 
     assert(result.getAs[Double]("estimate") == 100.0)
   }
@@ -46,7 +46,7 @@ class ThetaTest extends SparkSessionManager {
       FROM
         theta_input_table
     """)
-    assert(df.head.getAs[Double]("estimate") == 100.0)
+    assert(df.head().getAs[Double]("estimate") == 100.0)
   }
 
   test("Theta Sketch build via SQL with lgk") {
@@ -62,7 +62,7 @@ class ThetaTest extends SparkSessionManager {
       FROM
         theta_input_table
     """)
-    assert(df.head.getAs[Double]("estimate") == 100.0)
+    assert(df.head().getAs[Double]("estimate") == 100.0)
   }
 
   test("Theta Union via Scala") {
@@ -72,7 +72,7 @@ class ThetaTest extends SparkSessionManager {
 
     val groupedDf = data.groupBy("group").agg(theta_sketch_agg_build("value").as("sketch"))
     val mergedDf = groupedDf.agg(theta_sketch_agg_union("sketch").as("merged"))
-    val result: Row = mergedDf.select(theta_sketch_get_estimate("merged").as("estimate")).head
+    val result: Row = mergedDf.select(theta_sketch_get_estimate("merged").as("estimate")).head()
     assert(result.getAs[Double]("estimate") == numDistinct)
   }
 
@@ -100,7 +100,7 @@ class ThetaTest extends SparkSessionManager {
       FROM
         theta_sketch_table
     """)
-    assert(mergedDf.head.getAs[Double]("estimate") == numDistinct)
+    assert(mergedDf.head().getAs[Double]("estimate") == numDistinct)
   }
 
   test("Theta Union via SQL with lgk") {
@@ -126,7 +126,7 @@ class ThetaTest extends SparkSessionManager {
       FROM
         theta_sketch_table
     """)
-    assert(mergedDf.head.getAs[Double]("estimate") == numDistinct)
+    assert(mergedDf.head().getAs[Double]("estimate") == numDistinct)
   }
 
 }


### PR DESCRIPTION
* Renamed KllExpressions to KllDoublesSketchExpressions, in line with other changes
* Changes to remove deprecation warnings when running with scala 2.13
* Declare main version defaults in build.sbt
* Update workflow to test scala 2.12 and 2.13

This won't work with scala 3 currently. That'll requires a bit more tinkering with build.sbt, but I'm unclear if it's a priority based on actual usage at this point.