### PR TITLE
Support java17 with pyspark -- maybe

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       # using fixed versions for CI; can expand if building wheels for pypi
       matrix:
-        jdk: [ 11 ]
+        jdk: [ 11, 17 ]
         scala: [ 2.12.20 ]
         spark: [ 3.5.4 ]
 

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ that can be used to configure the project:
 The package is built using `sbt package` and tests are
 run with `sbt test`.
 
-If building for the pyspark package, we currently recommend using
-Java 11, even if the library will be used with later Java versions.
+If building for the pyspark package, please also read
+[python/README.md](python/README.md).

--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@ This is the PySpark plugin component.
 ## Usage
 
 There are several Spark config options needed to use the library.
-`tests/conftest.py` provides a basic example. The key settings to
+[tests/conftest.py](tests/conftest.py) provides a basic example. The key settings to
 note are:
 
 * `.config("spark.driver.userClassPathFirst", "true")`
@@ -34,13 +34,15 @@ note are:
 * `.config("spark.driver.extraClassPath", get_dependency_classpath())`
 * `.config("spark.executor.extraClassPath", get_dependency_classpath())`
 
-Starting with Spark 3.5, the Spark includes an older version of the DataSketches java library, so Spark needs to know to use the
-provided verison.
+Starting with Spark 3.5, Spark includes an older version of the DataSketches java library, so Spark needs to know to use the provided verison.
 
-Initial testing with Java 17 indicates that there may be
-additional configuration options needed to enable the
-use of MemorySegment. For now we suggest using a base library
-compiled for Java 11 with pyspark.
+When using a datasketches-spark library compiled for Java 17 or newer, there are additional configuration options needed. Specifically, you must enable the `jdk.incubator.foreign` module in both the Spark driver and executors. Especially for the driver, this must be specified prior to creating the JVM; the module cannot be added once the JVM is initialized.
+
+Looking again at [tests/conftest.py](tests/conftest.py), we need to add
+
+* `.config('spark.executor.extraJavaOptions', java_opts)`
+
+with `java_opts` set to `--add-modules=jdk.incubator.foreign --add-exports=java.base/sun.nio.ch=ALL-UNNAMED'`. We must also use that value to specify `--driver-java-options ${java_opts}`. That option may be specified either via the `PYSPARK_SUBMIT_ARGS` environment variable if running a python script directly, or as a command-line argument to `spark-submit` if submitting to a cluster.
 
 ## Build and Test Instructions
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,20 +15,67 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
+import subprocess
 import pytest
+from typing import Optional
 from pyspark.sql import SparkSession
 from datasketches_spark import get_dependency_classpath
 
-@pytest.fixture(scope="session")
+# Attempt to determin the Java version -- this may still fail
+# based on command line arguments or other pyspark config, but
+# it should often work for local testing.
+# Favor looking for a java executable in $SPARK_HOME, else
+# $JAVA_HOME, else $PATH from just running `java`
+# May return an incorrect number for Java 8 (aka 1.8) but
+# we only care about detecting 17 and higher
+def get_java_version() -> Optional[int]:
+    java_cmd = 'java' # fallback option
+    # check $JAVA_HOME first
+    if 'JAVA_HOME' in os.environ:
+        java_cmd = os.path.join(os.environ['JAVA_HOME'], 'bin', 'java')
+
+    # check $SPARK_HOME next -- top choice, if available
+    if 'SPARK_HOME' in os.environ:
+        spark_java = os.path.join(os.environ['SPARK_HOME'], 'bin', 'java')
+        if os.path.exists(spark_java):
+            java_cmd = spark_java
+
+    # now attempt to run java --version
+    try:
+        # java -version prints to stderr
+        # Version is the 3nd argument of the 1st line and may be in double quotes
+        # We care only about the major version
+        output = subprocess.run([java_cmd, '-version'],
+                                capture_output=True,
+                                text=True)
+        version = output.stderr.splitlines()[0]
+        return int(version.split()[2].strip('"').split('.')[0])
+
+    except Exception as e:
+        print(f"Could not determine java version: {e}")
+        return None
+
+@pytest.fixture(scope='session')
 def spark():
+    java_opts = ''
+    java_version = get_java_version()
+
+    if java_version is not None and java_version >= 17 and java_version < 21:
+        java_opts = '--add-modules=jdk.incubator.foreign --add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+        os.environ['PYSPARK_SUBMIT_ARGS'] = f"--driver-java-options '{java_opts}' pyspark-shell"
+
     spark = (
         SparkSession.builder
-        .appName("test")
-        .master("local[*]")
-        .config("spark.driver.userClassPathFirst", "true")
-        .config("spark.executor.userClassPathFirst", "true")
-        .config("spark.driver.extraClassPath", get_dependency_classpath())
-        .config("spark.executor.extraClassPath", get_dependency_classpath())
+        .appName('test')
+        .master('local[1]')
+        .config('spark.driver.userClassPathFirst', 'true')
+        .config('spark.executor.userClassPathFirst', 'true')
+        .config('spark.driver.extraClassPath', get_dependency_classpath())
+        .config('spark.executor.extraClassPath', get_dependency_classpath())
+        .config('spark.executor.extraJavaOptions', java_opts)
+        .config('spark.driver.bindAddress', 'localhost')
+        .config('spark.driver.host', 'localhost')
         .getOrCreate()
     )
     yield spark

--- a/src/test/scala/org/apache/spark/sql/datasketches/SparkSessionManager.scala
+++ b/src/test/scala/org/apache/spark/sql/datasketches/SparkSessionManager.scala
@@ -34,6 +34,8 @@ trait SparkSessionManager extends AnyFunSuite with BeforeAndAfterAll {
       .builder()
       .appName("datasketches-spark-tests")
       .master("local[3]")
+      .config("spark.driver.bindAddress", "localhost")
+      .config("spark.driver.host", "localhost")
       //.config("spark.sql.debug.codegen", "true")
       .getOrCreate()
 


### PR DESCRIPTION
Two changes here:
* Should add support for using the java17 version of the core sketches library in pytest. If this works I'll try to add more to the readme to descrive what's needed
* Caught a codegen issue during testing since I had variable names hard-coded, which caused collisions when get_pmf() and get_cdf() were generated in the same block.

The second could have been separate, but I found it while I had debug uptions enabled for the former so just fixed it here. Sorry for mixing themes.