### PR TITLE
Test improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,19 +63,10 @@ jobs:
           echo Scala version: $SCALA_VERSION
           echo Spark version: $SPARK_VERSION
 
-      - name: Build and test
+      - name: Build and test interpreted path
         run: >
-          sbt ++$SCALA_VERSION --batch clean test
+          CODEGEN_FACTORYMODE=NO_CODEGEN sbt ++$SCALA_VERSION --batch clean test
 
-      - name: Build and test with Codegen
+      - name: Build and test codegen path
         run: >
-          FORCE_CODEGEN=true sbt ++$SCALA_VERSION --batch clean test
-
-
-# Architecture options: x86, x64, armv7, aarch64, ppc64le
-# setup-java@v4 has a "with cache" option
-# Lifecycle: validate, compile, test, package, verify, install, deploy
-# -B batch mode, never stops for user input
-# -V show Version without stopping
-# -X debug mode
-# -q quiet, only show errors
+          CODEGEN_FACTORYMODE=ONLY_CODEGEN sbt ++$SCALA_VERSION --batch clean test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,4 +69,4 @@ jobs:
 
       - name: Build and test codegen path
         run: >
-          CODEGEN_FACTORYMODE=ONLY_CODEGEN sbt ++$SCALA_VERSION --batch clean test
+          CODEGEN_FACTORYMODE=CODEGEN_ONLY sbt ++$SCALA_VERSION --batch clean test

--- a/src/test/scala/org/apache/spark/sql/datasketches/SparkSessionManager.scala
+++ b/src/test/scala/org/apache/spark/sql/datasketches/SparkSessionManager.scala
@@ -46,7 +46,7 @@ trait SparkSessionManager extends AnyFunSuite with BeforeAndAfterAll {
       .config("spark.sql.codegen.factoryMode", codegenState)
 
     // additional flags used for codegen state
-    if ("ONLY_CODEGEN".equals(codegenState)) {
+    if ("CODEGEN_ONLY".equals(codegenState)) {
       builder
         .config("spark.sql.codegen.wholeStage", "true")
         .config("spark.sql.codegen.fallback", "false")


### PR DESCRIPTION
I believe this successfully forces into codegen or interpreted mode. It'd be nice to be able to control it directly from sbt but I haven't fully internalized sbt's model well enough to figure it out at this point.

`sbt test` will default to the normal mode of trying codgen where appropriate and falling back to interpreted mode if that fails. But for CI I'm testing only all-codegen or no-codegen since we want to ensure things work in both modes. Fallback is kind of annoying in that it can leave one of the two paths entirely untested!

My confidence in the code will be much higher after this is merged. Whew.