### PR TITLE
add function to cast sketches to BinaryType to handle spark weirdness

### DIFF
--- a/python/tests/kll_test.py
+++ b/python/tests/kll_test.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pyspark.sql.types import StructType, StructField, DoubleType, IntegerType
+from pyspark.sql.types import StructType, StructField, BinaryType, DoubleType, IntegerType
 
-from datasketches import kll_doubles_sketch
+#from datasketches import kll_doubles_sketch
+from datasketches_spark.common import cast_to_binary
 from datasketches_spark.kll import *
 
 def test_kll_build(spark):
@@ -44,6 +45,14 @@ def test_kll_build(spark):
   assert(sk.get_max_value() == result["max"])
   assert(sk.get_pmf([25000, 30000, 75000]) == result["pmf"])
   assert(sk.get_cdf([20000, 50000, 95000], False) == result["cdf"])
+
+  df_types = df_agg.select(
+    "sketch",
+    cast_to_binary("sketch").alias("asBinary")
+  )
+  assert(df_types.schema["sketch"].dataType == KllDoublesSketchUDT())
+  assert(df_types.schema["asBinary"].dataType == BinaryType())
+
 
 def test_kll_merge(spark):
   n = 75 # stay in exact mode

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/CastToBinary.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/CastToBinary.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.datasketches.common
+
+import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, BinaryType, DataType}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ExpectsInputTypes}
+import org.apache.spark.sql.catalyst.expressions.UnaryExpression
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeBlock, CodegenContext, ExprCode}
+
+@ExpressionDescription(
+  usage = """
+    _FUNC_(expr) - Returns the input as a BinaryType (Array[Byte]). """
+/*    ,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(kll_sketch_agg(col)) FROM VALUES (1.0), (2.0), (3.0) tab(col);
+       1.0
+  """*/
+  //group = "misc_funcs",
+)
+case class CastToBinary(sketchExpr: Expression)
+ extends UnaryExpression
+ with ExpectsInputTypes {
+
+  override def child: Expression = sketchExpr
+
+  override protected def withNewChildInternal(newChild: Expression): CastToBinary = {
+    copy(sketchExpr = newChild)
+  }
+
+  override def prettyName: String = "sketch_to_binary_converter"
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
+
+  override def dataType: DataType = BinaryType
+
+  override def nullSafeEval(input: Any): Any = {
+    input.asInstanceOf[Array[Byte]]
+  }
+
+  override protected def nullSafeCodeGen(ctx: CodegenContext, ev: ExprCode, f: String => String): ExprCode = {
+    val sketchEval = child.genCode(ctx)
+
+    val code =
+      s"""
+         |${sketchEval.code}
+         |final byte[] ${ev.value} = ${sketchEval.value};
+         |final boolean ${ev.isNull} = ${sketchEval.isNull};
+       """.stripMargin
+    ev.copy(code = CodeBlock(Seq(code), Seq.empty))
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    nullSafeCodeGen(ctx, ev, c => s"($c)")
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/CastToBinary.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/CastToBinary.scala
@@ -25,12 +25,6 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodeBlock, CodegenCont
 @ExpressionDescription(
   usage = """
     _FUNC_(expr) - Returns the input as a BinaryType (Array[Byte]). """
-/*    ,
-  examples = """
-    Examples:
-      > SELECT _FUNC_(kll_sketch_agg(col)) FROM VALUES (1.0), (2.0), (3.0) tab(col);
-       1.0
-  """*/
   //group = "misc_funcs",
 )
 case class CastToBinary(sketchExpr: Expression)
@@ -43,7 +37,7 @@ case class CastToBinary(sketchExpr: Expression)
     copy(sketchExpr = newChild)
   }
 
-  override def prettyName: String = "sketch_to_binary_converter"
+  override def prettyName: String = "cast_to_binary"
 
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
@@ -58,3 +58,10 @@ trait DatasketchesFunctionRegistry {
     (name, (expressionInfo, builder))
   }
 }
+
+// object for common functions
+object CommonFunctionRegistry extends DatasketchesFunctionRegistry {
+  override val expressions: Map[String, (ExpressionInfo, FunctionBuilder)] = Map(
+    expression[CastToBinary]("cast_to_binary"),
+  )
+}

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.datasketches.common
+
+import org.apache.spark.sql.Column
+
+object functions extends DatasketchesScalaFunctionBase {
+
+  def cast_to_binary(expr: Column): Column = withExpr {
+    new CastToBinary(expr.expr)
+  }
+
+  def sketch_to_binary(columnName: String): Column = {
+    cast_to_binary(Column(columnName))
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
+++ b/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.types.{StructType, StructField, IntegerType, BinaryT
 import org.apache.datasketches.kll.KllDoublesSketch
 import org.apache.spark.sql.datasketches.kll.functions._
 import org.apache.spark.sql.datasketches.kll.types.KllDoublesSketchType
-import org.apache.spark.sql.datasketches.common.SparkSessionManager
+import org.apache.spark.sql.datasketches.common.{SparkSessionManager, CommonFunctionRegistry}
+import org.apache.spark.sql.datasketches.common.functions.cast_to_binary
 
 class KllTest extends SparkSessionManager {
   import spark.implicits._
@@ -116,11 +117,16 @@ class KllTest extends SparkSessionManager {
 
     val cdf_excl = Array[Double](0.2, 0.49, 1.0, 1.0)
     compareArrays(cdf_excl, pmfCdfResult.getAs[Seq[Double]]("cdf_exclusive").toArray)
+
+    val resultSchema = sketchDf.select($"sketch", cast_to_binary($"sketch").as("asBinary")).schema
+    assert(resultSchema.apply("sketch").dataType.equals(KllDoublesSketchType))
+    assert(resultSchema.apply("asBinary").dataType.equals(BinaryType))
   }
 
   test("Kll Doubles Sketch via SQL") {
     // register KLL functions
     KllFunctionRegistry.registerFunctions(spark)
+    CommonFunctionRegistry.registerFunctions(spark)
 
     val n = 100
     val data = (for (i <- 1 to n) yield i.toDouble).toDF("value")
@@ -167,6 +173,21 @@ class KllTest extends SparkSessionManager {
 
     val cdf_excl = Array[Double](0.2, 0.49, 1.0, 1.0)
     compareArrays(cdf_excl, pmfCdfResult.getAs[Seq[Double]]("cdf_exclusive").toArray)
+
+    val schemaCheckResult = spark.sql(
+      s"""
+      |SELECT
+      |  kll_sketch_double_agg_build(value, 200) AS sketch,
+      |  cast_to_binary(kll_sketch_double_agg_build(value, 200)) AS asBinary
+      |FROM
+      |  data_table
+      """.stripMargin
+    )
+
+    val resultSchema = schemaCheckResult.schema
+    assert(resultSchema.apply("sketch").dataType.equals(KllDoublesSketchType))
+    assert(resultSchema.apply("asBinary").dataType.equals(BinaryType))
+
   }
 
   test("KLL Doubles Merge via Scala") {


### PR DESCRIPTION
This seems needed for BigQuery connectors, and ultimately anywhere that wants to accept BinaryType data even though the serialized sketches are a type of BinaryType.