### PR TITLE
rename cast_to_binary to cast_as_binary

### DIFF
--- a/python/src/datasketches_spark/common.py
+++ b/python/src/datasketches_spark/common.py
@@ -133,4 +133,4 @@ def _get_common_functions_class() -> JavaClass:
 
 @try_remote_functions
 def cast_as_binary(col: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns(_get_common_functions_class(), "cast_to_binary", col)
+    return _invoke_function_over_columns(_get_common_functions_class(), "cast_as_binary", col)

--- a/python/src/datasketches_spark/common.py
+++ b/python/src/datasketches_spark/common.py
@@ -132,5 +132,5 @@ def _get_common_functions_class() -> JavaClass:
 
 
 @try_remote_functions
-def cast_to_binary(col: "ColumnOrName") -> Column:
+def cast_as_binary(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns(_get_common_functions_class(), "cast_to_binary", col)

--- a/python/tests/kll_test.py
+++ b/python/tests/kll_test.py
@@ -18,7 +18,7 @@
 from pyspark.sql.types import StructType, StructField, BinaryType, DoubleType, IntegerType
 
 #from datasketches import kll_doubles_sketch
-from datasketches_spark.common import cast_to_binary
+from datasketches_spark.common import cast_as_binary
 from datasketches_spark.kll import *
 
 def test_kll_build(spark):
@@ -48,7 +48,7 @@ def test_kll_build(spark):
 
   df_types = df_agg.select(
     "sketch",
-    cast_to_binary("sketch").alias("asBinary")
+    cast_as_binary("sketch").alias("asBinary")
   )
   assert(df_types.schema["sketch"].dataType == KllDoublesSketchUDT())
   assert(df_types.schema["asBinary"].dataType == BinaryType())

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/CastAsBinary.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/CastAsBinary.scala
@@ -27,17 +27,17 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodeBlock, CodegenCont
     _FUNC_(expr) - Returns the input as a BinaryType (Array[Byte]). """
   //group = "misc_funcs",
 )
-case class CastToBinary(sketchExpr: Expression)
+case class CastAsBinary(sketchExpr: Expression)
  extends UnaryExpression
  with ExpectsInputTypes {
 
   override def child: Expression = sketchExpr
 
-  override protected def withNewChildInternal(newChild: Expression): CastToBinary = {
+  override protected def withNewChildInternal(newChild: Expression): CastAsBinary = {
     copy(sketchExpr = newChild)
   }
 
-  override def prettyName: String = "cast_to_binary"
+  override def prettyName: String = "cast_as_binary"
 
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
@@ -62,6 +62,6 @@ trait DatasketchesFunctionRegistry {
 // object for common functions
 object CommonFunctionRegistry extends DatasketchesFunctionRegistry {
   override val expressions: Map[String, (ExpressionInfo, FunctionBuilder)] = Map(
-    expression[CastToBinary]("cast_to_binary"),
+    expression[CastAsBinary]("cast_to_binary"),
   )
 }

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/DatasketchesFunctionRegistry.scala
@@ -62,6 +62,6 @@ trait DatasketchesFunctionRegistry {
 // object for common functions
 object CommonFunctionRegistry extends DatasketchesFunctionRegistry {
   override val expressions: Map[String, (ExpressionInfo, FunctionBuilder)] = Map(
-    expression[CastAsBinary]("cast_to_binary"),
+    expression[CastAsBinary]("cast_as_binary"),
   )
 }

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.Column
 object functions extends DatasketchesScalaFunctionBase {
 
   def cast_to_binary(expr: Column): Column = withExpr {
-    new CastToBinary(expr.expr)
+    new CastAsBinary(expr.expr)
   }
 
   def sketch_to_binary(columnName: String): Column = {

--- a/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/datasketches/common/functions.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.Column
 
 object functions extends DatasketchesScalaFunctionBase {
 
-  def cast_to_binary(expr: Column): Column = withExpr {
+  def cast_as_binary(expr: Column): Column = withExpr {
     new CastAsBinary(expr.expr)
   }
 
-  def sketch_to_binary(columnName: String): Column = {
-    cast_to_binary(Column(columnName))
+  def sketch_as_binary(columnName: String): Column = {
+    cast_as_binary(Column(columnName))
   }
 }

--- a/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
+++ b/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
@@ -26,7 +26,7 @@ import org.apache.datasketches.kll.KllDoublesSketch
 import org.apache.spark.sql.datasketches.kll.functions._
 import org.apache.spark.sql.datasketches.kll.types.KllDoublesSketchType
 import org.apache.spark.sql.datasketches.common.{SparkSessionManager, CommonFunctionRegistry}
-import org.apache.spark.sql.datasketches.common.functions.cast_to_binary
+import org.apache.spark.sql.datasketches.common.functions.cast_as_binary
 
 class KllTest extends SparkSessionManager {
   import spark.implicits._
@@ -118,7 +118,7 @@ class KllTest extends SparkSessionManager {
     val cdf_excl = Array[Double](0.2, 0.49, 1.0, 1.0)
     compareArrays(cdf_excl, pmfCdfResult.getAs[Seq[Double]]("cdf_exclusive").toArray)
 
-    val resultSchema = sketchDf.select($"sketch", cast_to_binary($"sketch").as("asBinary")).schema
+    val resultSchema = sketchDf.select($"sketch", cast_as_binary($"sketch").as("asBinary")).schema
     assert(resultSchema.apply("sketch").dataType.equals(KllDoublesSketchType))
     assert(resultSchema.apply("asBinary").dataType.equals(BinaryType))
   }

--- a/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
+++ b/src/test/scala/org/apache/spark/sql/datasketches/kll/KllTest.scala
@@ -178,7 +178,7 @@ class KllTest extends SparkSessionManager {
       s"""
       |SELECT
       |  kll_sketch_double_agg_build(value, 200) AS sketch,
-      |  cast_to_binary(kll_sketch_double_agg_build(value, 200)) AS asBinary
+      |  cast_as_binary(kll_sketch_double_agg_build(value, 200)) AS asBinary
       |FROM
       |  data_table
       """.stripMargin


### PR DESCRIPTION
Slightly better aligns syntax with SQL casts